### PR TITLE
Change Fedora version for which packages are built

### DIFF
--- a/site/download.html
+++ b/site/download.html
@@ -96,11 +96,11 @@ sudo apt-get install crawl
 # install tiles version
 sudo apt-get install crawl-tiles</pre>
                     </ul>
-                    <h4>Fedora 21</h4>
-                    <p>BlasterBlade provides Fedora packages for Crawl (0.16.1 tiles and console builds) in the openSUSE Build System repository. To install the tiles version, run the following (for Fedora 20, replace the 21 in the URL):</p>
+                    <h4>Fedora 22/21</h4>
+                    <p>BlasterBlade provides Fedora packages for Crawl (0.16.1 tiles and console builds) in the openSUSE Build System repository. To install the tiles version, run the following (for Fedora 21, replace the 22 in the URL):</p>
                     <pre>cd /etc/yum.repos.d/
 # Install the source repository
-sudo wget http://download.opensuse.org/repositories/home:nazar554/Fedora_21/home:nazar554.repo
+sudo wget http://download.opensuse.org/repositories/home:nazar554/Fedora_22/home:nazar554.repo
 # install tiles version
 sudo yum install crawl-sdl crawl-data
 # install console version


### PR DESCRIPTION
Fedora 20 is EOL, OBS buildsystem already removed support for it. Fedora 22 packages are being built now.

P.S. I am the Fedora packager guy. (This is my github account).